### PR TITLE
Fix minor formatting issue in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All transactions go through the same steps of being displayed for review before 
 
 ## Translations
 
-- Go to [https://crowdin.com/project/stargazer] and sign up.
+- Go to https://crowdin.com/project/stargazer and sign up.
 - Select the language you want to translate.
 - Select the "en.json" file.
 - Start translating words/phrases.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All transactions go through the same steps of being displayed for review before 
 
 ## Translations
 
-- Go to [https://crowdin.com/project/stargazer]() and sign up.
+- Go to [https://crowdin.com/project/stargazer] and sign up.
 - Select the language you want to translate.
 - Select the "en.json" file.
 - Start translating words/phrases.


### PR DESCRIPTION
translation link went to nowhere.  Removed extra .md formatting so that it would be treated as a standard hyperlink that goes to the right place when clicked.